### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/crazyscot/littertray/compare/v0.1.0...v0.2.0)
+
+### 🐛 Bug Fixes
+
+- [**breaking**] Overhaul locking soundness, return types - ([e09294a](https://github.com/crazyscot/littertray/commit/e09294a1ee0f7b994081d4785ffc8f70c057217b))
+
+### 🏗️ Build, packaging & CI
+
+- Allow building on rust 1.81, without the `async` feature - ([b608f82](https://github.com/crazyscot/littertray/commit/b608f8261305ae76d2859f924ce928b553775199))
+- Include doctests in code coverage - ([c4013d8](https://github.com/crazyscot/littertray/commit/c4013d8397d87ab29d8d9d95f64216cae3122275))
+
+### ⚙️ Miscellaneous Tasks
+
+- Enable all features on rust-analyzer, resolve warnings - ([4781ac9](https://github.com/crazyscot/littertray/commit/4781ac90df62c7874f0da7236f162597249a1c3c))
+- Fix badges on README - ([0c98f15](https://github.com/crazyscot/littertray/commit/0c98f1554dfa01233e30d0af1c25b63af5fdd69a))
+
+
 ## [0.1.0]
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "littertray"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "littertray"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ross Younger <crazyscot@gmail.com>"]
 description = "Lightweight sandboxing for tests that write to the filesystem"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `littertray`: 0.1.0 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/crazyscot/littertray/compare/v0.1.0...v0.2.0)

### 🐛 Bug Fixes

- [**breaking**] Overhaul locking soundness, return types - ([e09294a](https://github.com/crazyscot/littertray/commit/e09294a1ee0f7b994081d4785ffc8f70c057217b))

### 🏗️ Build, packaging & CI

- Allow building on rust 1.81, without the `async` feature - ([b608f82](https://github.com/crazyscot/littertray/commit/b608f8261305ae76d2859f924ce928b553775199))
- Include doctests in code coverage - ([c4013d8](https://github.com/crazyscot/littertray/commit/c4013d8397d87ab29d8d9d95f64216cae3122275))

### ⚙️ Miscellaneous Tasks

- Enable all features on rust-analyzer, resolve warnings - ([4781ac9](https://github.com/crazyscot/littertray/commit/4781ac90df62c7874f0da7236f162597249a1c3c))
- Fix badges on README - ([0c98f15](https://github.com/crazyscot/littertray/commit/0c98f1554dfa01233e30d0af1c25b63af5fdd69a))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).