### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/crazyscot/littertray/compare/v0.2.0...v0.2.1)
+
+### ⚙️ Miscellaneous Tasks
+
+- _(ci)_ Overhaul CI - ([584fa5e](https://github.com/crazyscot/littertray/commit/584fa5eaab71df7b9496b7ea1c5370c28652407b))
+- _(ci,deps)_: bump codecov/codecov-action from 5.4.2 to 5.4.3 - ([2ccb4a9](https://github.com/crazyscot/littertray/commit/2ccb4a9f1c8c44d9fa2e1e3210b02d64b41b2152))
+
 ## [0.2.0](https://github.com/crazyscot/littertray/compare/v0.1.0...v0.2.0)
 
 ### 🐛 Bug Fixes
@@ -22,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable all features on rust-analyzer, resolve warnings - ([4781ac9](https://github.com/crazyscot/littertray/commit/4781ac90df62c7874f0da7236f162597249a1c3c))
 - Fix badges on README - ([0c98f15](https://github.com/crazyscot/littertray/commit/0c98f1554dfa01233e30d0af1c25b63af5fdd69a))
-
 
 ## [0.1.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "littertray"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "littertray"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ross Younger <crazyscot@gmail.com>"]
 description = "Lightweight sandboxing for tests that write to the filesystem"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `littertray`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/crazyscot/littertray/compare/v0.2.0...v0.2.1)

### ⚙️ Miscellaneous Tasks

- *(ci)* Overhaul CI - ([584fa5e](https://github.com/crazyscot/littertray/commit/584fa5eaab71df7b9496b7ea1c5370c28652407b))
- Chore(ci)(deps): bump codecov/codecov-action from 5.4.2 to 5.4.3 - ([2ccb4a9](https://github.com/crazyscot/littertray/commit/2ccb4a9f1c8c44d9fa2e1e3210b02d64b41b2152))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).